### PR TITLE
Configure NEML2 executor with both volume and boundary batch index generators

### DIFF
--- a/framework/include/neml2/actions/NEML2Action.h
+++ b/framework/include/neml2/actions/NEML2Action.h
@@ -138,8 +138,11 @@ protected:
   /// Name of the NEML2Executor user object
   const UserObjectName _executor_name;
 
-  /// Name of the NEML2BatchIndexGenerator user object
+  /// Name of the element-based NEML2BatchIndexGenerator user object
   const UserObjectName _idx_generator_name;
+
+  /// Name of the boundary-based NEML2BoundaryBatchIndexGenerator user object
+  const UserObjectName _bnd_idx_generator_name;
 
   /// Blocks this sub-block action applies to
   const std::vector<SubdomainName> _block;

--- a/framework/src/neml2/actions/NEML2Action.C
+++ b/framework/src/neml2/actions/NEML2Action.C
@@ -56,9 +56,14 @@ NEML2Action::validParams()
                                "model's name, and <block-name> is this action sub-block's name.");
   params.addParam<std::string>(
       "batch_index_generator_name",
-      "Name of the NEML2BatchIndexGenerator user object. The default name is "
+      "Name of the element-based NEML2BatchIndexGenerator user object. The default name is "
       "'neml2_index_<model-name>_<block-name>' where <model-name> is the NEML2 model's name, and "
       "<block-name> is this action sub-block's name.");
+  params.addParam<std::string>(
+      "boundary_batch_index_generator_name",
+      "Name of the boundary-based NEML2BoundaryBatchIndexGenerator user object. The default "
+      "name is 'neml2_boundary_index_<model-name>_<block-name>' where <model-name> is the NEML2 "
+      "model's name, and <block-name> is this action sub-block's name.");
   params.addParam<std::vector<SubdomainName>>(
       "block", {}, "List of blocks (subdomains) where the material model is defined");
   params.addParam<std::vector<BoundaryName>>(
@@ -74,6 +79,10 @@ NEML2Action::NEML2Action(const InputParameters & params)
     _idx_generator_name(isParamValid("batch_index_generator_name")
                             ? getParam<std::string>("batch_index_generator_name")
                             : "neml2_index_" + getParam<std::string>("model") + "_" + name()),
+    _bnd_idx_generator_name(isParamValid("boundary_batch_index_generator_name")
+                                ? getParam<std::string>("boundary_batch_index_generator_name")
+                                : "neml2_boundary_index_" + getParam<std::string>("model") +
+                                      "_" + name()),
     _block(getParam<std::vector<SubdomainName>>("block")),
     _bnd(getParam<std::vector<BoundaryName>>("boundary"))
 {
@@ -284,12 +293,24 @@ NEML2Action::act()
                    param.moose.name);
     }
 
-    // The index generator UO
+    // The element-based index generator UO
     {
-      auto type = "NEML2" + bnd_prefix + "BatchIndexGenerator";
+      auto type = "NEML2BatchIndexGenerator";
       auto params = _factory.getValidParams(type);
       params.applyParameters(parameters());
+      if (is_blk)
+        params.set<std::vector<SubdomainName>>("block") = _block;
       _problem->addUserObject(type, _idx_generator_name, params);
+    }
+
+    // The boundary-based index generator UO
+    {
+      auto type = "NEML2BoundaryBatchIndexGenerator";
+      auto params = _factory.getValidParams(type);
+      params.applyParameters(parameters());
+      if (is_bnd)
+        params.set<std::vector<BoundaryName>>("boundary") = _bnd;
+      _problem->addUserObject(type, _bnd_idx_generator_name, params);
     }
 
     // The Executor UO
@@ -297,10 +318,8 @@ NEML2Action::act()
       auto type = "NEML2ModelExecutor";
       auto params = _factory.getValidParams(type);
       params.applyParameters(parameters());
-      if (is_bnd)
-        params.set<UserObjectName>("boundary_batch_index_generator") = _idx_generator_name;
-      else
-        params.set<UserObjectName>("batch_index_generator") = _idx_generator_name;
+      params.set<UserObjectName>("batch_index_generator") = _idx_generator_name;
+      params.set<UserObjectName>("boundary_batch_index_generator") = _bnd_idx_generator_name;
       params.set<std::vector<UserObjectName>>("gatherers") = gatherers;
       params.set<std::vector<UserObjectName>>("param_gatherers") = param_gatherers;
       _problem->addUserObject(type, _executor_name, params);

--- a/framework/src/neml2/userobjects/NEML2ModelExecutor.C
+++ b/framework/src/neml2/userobjects/NEML2ModelExecutor.C
@@ -100,11 +100,11 @@ NEML2ModelExecutor::NEML2ModelExecutor(const InputParameters & params)
 #ifdef NEML2_ENABLED
   validateModel();
 
-  // NEML2 executor either operates on elements or interfaces, not both
-  if (bool(_batch_index_generator) == bool(_bnd_batch_index_generator))
+  // At least one index generator must be provided for batch lookup.
+  if (!_batch_index_generator && !_bnd_batch_index_generator)
     paramError("batch_index_generator",
-               "Exactly one of 'batch_index_generator' or 'boundary_batch_index_generator' must be "
-               "provided.");
+               "At least one of 'batch_index_generator' or 'boundary_batch_index_generator' must "
+               "be provided.");
 
   // add user object dependencies by name (the UOs do not need to exist yet for this)
   for (const auto & gatherer_name : getParam<std::vector<UserObjectName>>("gatherers"))


### PR DESCRIPTION
### Motivation
- Material batch indexing must be chosen at material-evaluation time based on `Material::_bnd`, so the executor needs access to both element and boundary batch index generators rather than action-time selecting one.
- The previous action logic could wire only one generator into the `NEML2ModelExecutor`, which can lead to runtime failures when a `NEML2ToMOOSEMaterialProperty` evaluates in the opposite context (volume vs face).

### Description
- Add an optional `boundary_batch_index_generator_name` parameter and store both generator names on the action object (`_idx_generator_name`, `_bnd_idx_generator_name`).
- Always create both `NEML2BatchIndexGenerator` (element) and `NEML2BoundaryBatchIndexGenerator` (boundary) user objects in `NEML2Action::act()` and apply appropriate block/boundary restrictions to each generator.
- Wire both generator names into the `NEML2ModelExecutor` parameters so the executor can select the correct generator via its `getBatchIndex(elem_id, side_id, on_elem_side)` path at runtime.
- Relax `NEML2ModelExecutor` constructor validation to require at least one generator (instead of enforcing exactly one), allowing executors constructed with both generators to function correctly.
- Key modified files: `framework/src/neml2/actions/NEML2Action.C`, `framework/include/neml2/actions/NEML2Action.h`, and `framework/src/neml2/userobjects/NEML2ModelExecutor.C`.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff issues, and it passed.
- Attempted to run the NEML2 test harness via `./scripts/run_tests -i test/tests/neml2/tests`, but execution failed due to missing environment dependencies (missing `libmesh-config`, `hit` module, and Python `yaml`), so unit/integration tests could not be executed in this environment.
- No compile or runtime tests were performed due to the incomplete build/test environment.